### PR TITLE
CI: remove codecov upload, show coverage in logs only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,8 @@ jobs:
       - name: Run tests
         run: bun run test
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
-        if: always()
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+      - name: Show coverage report
+        run: bun run test:coverage || true
 
   build:
     name: Build


### PR DESCRIPTION
Removes Codecov upload from CI workflow and displays coverage in logs only. No external upload required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration for improved coverage report handling and error tolerance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->